### PR TITLE
added getGlobalId as Promise

### DIFF
--- a/viewer/bimserverviewer.js
+++ b/viewer/bimserverviewer.js
@@ -309,6 +309,21 @@ export class BimServerViewer {
 			});
 		});
 	}
+
+	getGlobalId(oid) {
+
+		return new Promise((resolve, reject) => {
+	
+			this.bimServerApi.call("LowLevelInterface", "getDataObjectByOid", {
+				roid: this.revisionId,
+				oid : oid
+			}, (data)=> {
+				// console.log("bimserver returend "+data.guid);
+				resolve(data.guid);
+			});
+
+		});
+	}
 	
 	loadDefaultLayer(defaultRenderLayer, revision, totalBounds, fieldsToInclude) {
 //		document.getElementById("progress").style.display = "block";


### PR DESCRIPTION
Asynchronous BimServerAPI call to get the corresponding IFC GUID of a selected object identified by an OID 

usage e.g.
```
let v = this._bimServerViewer.viewer;
		let selected = v.getSelected();
		selected.forEach(elem => {
			let id = this._bimServerViewer.getGlobalId(elem.oid).then
			(	
				function(result){
					console.log("getGlobalId returned "+result);
				},
				function(failed){
					console.log("could not get GUID");
				}
			);
			
		});	

```
