### PR TITLE
Solved error: "slice is not a method in v.camera._eye.slice(0) or v.camera._target.slice(0)" on bimsurfer.js getCamera() method.

### DIFF
--- a/viewer/bimsurfer.js
+++ b/viewer/bimsurfer.js
@@ -204,8 +204,8 @@ export class BimSurfer extends EventHandler {
 		let projectionType = v.camera.projectionType;
 		let json = {
 			type: projectionType,
-			eye: v.camera._eye.slice(0),
-			target: v.camera._target.slice(0),
+			eye: v.camera._eye.get().slice(0),
+			target: v.camera._target.get().slice(0),
 			up: v.camera._up.slice(0)
 		}
 		if (projectionType === "persp") {


### PR DESCRIPTION
Attributes of _Camera_ class `_eye` and `_target` are objects of type _AnimatedVec3_ and not _vec3_ so slice is not recognized as a method. Added `_eye.a` and `_target.a` for retrieving the _vec3_ arrays in order to use _slice_.